### PR TITLE
Simplify pretty_print_contract and introduce newline between contract heads

### DIFF
--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -104,13 +104,13 @@ defmodule Erlex do
       |> String.split(";")
 
     head =
-      if tail != [] do
-        head
-        |> String.trim_leading(to_string(module))
-        |> String.trim_leading(":")
-        |> String.trim_leading(to_string(function))
+      if Enum.empty?(tail) do
+          head
       else
-        head
+          head
+          |> String.trim_leading(to_string(module))
+          |> String.trim_leading(":")
+          |> String.trim_leading(to_string(function))
       end
 
     joiner = "\n"

--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -113,7 +113,7 @@ defmodule Erlex do
         head
       end
 
-    joiner = ""
+    joiner = "\n"
 
     Enum.map_join([head | tail], joiner, fn contract ->
       contract

--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -98,66 +98,47 @@ defmodule Erlex do
           function :: String.t()
         ) :: String.t()
   def pretty_print_contract(contract, module, function) do
-    multiple_heads? =
+    [head | tail] =
       contract
       |> to_string()
-      |> String.contains?(";")
+      |> String.split(";")
 
-    # TODO: This is kind of janky but I've only seen this once and am
-    # not sure how to make it happen generally.
-    if multiple_heads? do
-      [head | tail] =
-        contract
-        |> to_string()
-        |> String.split(";")
-
-      head =
+    head =
+      if tail != [] do
         head
         |> String.trim_leading(to_string(module))
         |> String.trim_leading(":")
         |> String.trim_leading(to_string(function))
+      else
+        head
+      end
 
-      joiner = "Contract head: "
+    joiner = ""
 
-      pretty =
-        Enum.map_join([head | tail], joiner, fn contract ->
-          contract
-          |> to_charlist()
-          |> pretty_print_contract()
-        end)
-
-      joiner <> pretty
-    else
-      pretty_print_contract(contract)
-    end
+    Enum.map_join([head | tail], joiner, fn contract ->
+      contract
+      |> to_charlist()
+      |> pretty_print_contract()
+    end)
   end
 
   @spec pretty_print_contract(contract :: String.t()) :: String.t()
   def pretty_print_contract(contract) do
-    multiple_heads? =
+    heads =
       contract
       |> to_string()
-      |> String.contains?(";")
+      |> String.split(";")
 
-    if multiple_heads? do
-      [head | tail] =
+    joiner = "Contract head: "
+
+    pretty =
+      Enum.map_join(heads, joiner, fn contract ->
         contract
-        |> to_string()
-        |> String.split(";")
+        |> to_charlist()
+        |> do_pretty_print_contract()
+      end)
 
-      joiner = "Contract head: "
-
-      pretty =
-        Enum.map_join([head | tail], joiner, fn contract ->
-          contract
-          |> to_charlist()
-          |> do_pretty_print_contract()
-        end)
-
-      joiner <> pretty
-    else
-      do_pretty_print_contract(contract)
-    end
+    joiner <> pretty
   end
 
   defp do_pretty_print_contract(contract) do

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -291,7 +291,7 @@ defmodule Erlex.Test.PretyPrintTest do
       )
 
     expected_output =
-      "Contract head: (any(), nil) :: nilContract head: (Ecto.Queryable.t(), String.t()) :: String.t()"
+      "Contract head: (any(), nil) :: nil\nContract head: (Ecto.Queryable.t(), String.t()) :: String.t()"
 
     assert pretty_printed == expected_output
   end


### PR DESCRIPTION
This merge request simplifies `pretty_print_contract/1,3` by reducing the case without multiple contracts/heads to the case of multiple contracts. It then adds a newline to separate multiple contracts.

Fix #3.