### PR TITLE
Do not print type vars as atom literals.

### DIFF
--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -507,8 +507,7 @@ defmodule Erlex do
   end
 
   defp do_pretty_print({:when_names, when_names, {:list, :paren, items}}) do
-    items = Enum.map(items, &trim_when_names(do_pretty_print(&1), when_names))
-    Enum.join(items, ", ")
+    Enum.map_join(items, ", ", &trim_when_names(do_pretty_print(&1), when_names))
   end
 
   defp do_pretty_print({:when_names, when_names, item}) do
@@ -535,9 +534,9 @@ defmodule Erlex do
       when_names
       |> Enum.map(fn {_, v} -> to_string(v) end)
 
-    printed = pretty_names |> Enum.reverse |> Enum.join(", ")
+    printed_whens = pretty_names |> Enum.reverse |> Enum.join(", ")
 
-    {printed, when_names}
+    {printed_whens, when_names}
   end
 
   defp atomize("Elixir." <> module_name) do

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -342,7 +342,7 @@ defmodule Erlex.Test.PretyPrintTest do
     pretty_printed = Erlex.pretty_print(input)
 
     expected_output =
-      "(:Atom, :Encoding) :: binary() when Atom: atom(), Encoding: :latin1 | :utf8"
+      "(Atom, Encoding) :: binary() when Atom: atom(), Encoding: :latin1 | :utf8"
 
     assert pretty_printed == expected_output
   end
@@ -420,7 +420,7 @@ defmodule Erlex.Test.PretyPrintTest do
 
     pretty_printed = Erlex.pretty_print_contract(input)
 
-    expected_output = "(:one, any(), Keyword.t()) :: :ok when one: key()"
+    expected_output = "(one, any(), Keyword.t()) :: :ok when one: key()"
     assert pretty_printed == expected_output
   end
 
@@ -432,6 +432,17 @@ defmodule Erlex.Test.PretyPrintTest do
     pretty_printed = assert Erlex.pretty_print_contract(input)
 
     expected_output = "() :: a when a: atom()"
+    assert pretty_printed == expected_output
+  end
+
+  test "type variable and atom argument types pretty print appropriately" do
+    input = ~S"""
+    (km, s, 'fnord') -> km when km :: term(), s :: atom()
+    """
+
+    pretty_printed = assert Erlex.pretty_print_contract(input)
+
+    expected_output = "(km, s, :fnord) :: km when km: term(), s: atom()"
     assert pretty_printed == expected_output
   end
 


### PR DESCRIPTION
This addresses the second part of jeremyjh/dialyxir#346. The issue there is contract type vars used in when clauses are formatted like they are an atom literal. 

e.g. 
```elixir
@spec do_stuff(avar) :: res when avar: term(), res: binary()
``` 
would get printed as  
```elixir
@spec do_stuff(:avar) :: :res when avar: term, res: binary
```

My fix is not beautiful, but I think its straightforward and low risk. We just make a list of all the names used in the when clause, and strip those names of a leading `:`.

I didn't pursue it too deeply but I think a possible alternative would be treat what gets lexed as `atom_part` as a name - in contracts atom literals come single quoted and lex as `:atom_full`. I really only looked at the contracts, you may already know this is is a non-starter. 

But for example the spec
```elixir
  @spec ok(km, :fnord) :: km when km: term
```

comes to us Erlangified in the contract arg as

`(km, s, 'fnord') -> km when km :: term(), s :: atom()`

Everything coming out of the `lex()` as `:atom_part` are non-atom-literals that we'll have to strip of ":" downstream. 
```
[
  {:"(", 1},
  {:atom_part, 1, 'k'},
  {:atom_part, 1, 'm'},
  {:",", 1},
  {:atom_part, 1, 's'},
  {:",", 1},
  {:atom_full, 1, '\'fnord\''},
  {:")", 1},
  {:->, 1},
  {:atom_part, 1, 'k'},
  {:atom_part, 1, 'm'},
  {:when, 1},
  {:atom_part, 1, 'k'},
  {:atom_part, 1, 'm'},
  {:::, 1},
  {:atom_part, 1, 't'},
  {:atom_part, 1, 'e'},
  {:atom_part, 1, 'r'},
  {:atom_part, 1, 'm'},
  {:"(", 1},
  {:")", 1},
  {:",", 1},
  {:atom_part, 1, 's'},
  {:::, 1},
  {:atom_part, 1, 'a'},
  {:atom_part, 1, 't'},
  {:atom_part, 1, 'o'},
  {:atom_part, 1, 'm'},
  {:"(", 1},
  {:")", 1}
]
```
