### PR TITLE
Lowercase Type Variables and Fix Underscore

### DIFF
--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -507,18 +507,18 @@ defmodule Erlex do
   end
 
   defp do_pretty_print({:when_names, when_names, {:list, :paren, items}}) do
-    Enum.map_join(items, ", ", &trim_when_names(do_pretty_print(&1), when_names))
+    Enum.map_join(items, ", ", &format_when_names(do_pretty_print(&1), when_names))
   end
 
   defp do_pretty_print({:when_names, when_names, item}) do
-    trim_when_names(do_pretty_print(item), when_names)
+    format_when_names(do_pretty_print(item), when_names)
   end
 
-  defp trim_when_names(item, when_names) do
+  defp format_when_names(item, when_names) do
     trimmed = String.trim_leading(item, ":")
 
     if trimmed in when_names do
-      trimmed
+      String.downcase(trimmed)
     else
       item
     end
@@ -527,7 +527,11 @@ defmodule Erlex do
   defp collect_and_print_whens(whens) do
     {pretty_names, when_names} =
       Enum.reduce(whens, {[], []}, fn {_, when_name, type}, {prettys, whens} ->
-        pretty_name = do_pretty_print({:named_type_with_appended_colon, when_name, type})
+        pretty_name =
+          {:named_type_with_appended_colon, when_name, type}
+          |> do_pretty_print()
+          |> String.downcase()
+
         {[pretty_name | prettys], [when_name | whens]}
       end)
 

--- a/lib/erlex.ex
+++ b/lib/erlex.ex
@@ -518,7 +518,7 @@ defmodule Erlex do
     trimmed = String.trim_leading(item, ":")
 
     if trimmed in when_names do
-      String.downcase(trimmed)
+      downcase_first(trimmed)
     else
       item
     end
@@ -530,18 +530,23 @@ defmodule Erlex do
         pretty_name =
           {:named_type_with_appended_colon, when_name, type}
           |> do_pretty_print()
-          |> String.downcase()
+          |> downcase_first()
 
         {[pretty_name | prettys], [when_name | whens]}
       end)
 
     when_names =
       when_names
-      |> Enum.map(fn {_, v} -> to_string(v) end)
+      |> Enum.map(fn {_, v} -> v |> atomize() |> String.trim_leading(":") end)
 
     printed_whens = pretty_names |> Enum.reverse() |> Enum.join(", ")
 
     {printed_whens, when_names}
+  end
+
+  defp downcase_first(string) do
+    {first, rest} = String.split_at(string, 1)
+    String.downcase(first) <> rest
   end
 
   defp atomize("Elixir." <> module_name) do

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -341,7 +341,7 @@ defmodule Erlex.Test.PretyPrintTest do
 
     pretty_printed = Erlex.pretty_print(input)
 
-    expected_output = "(Atom, Encoding) :: binary() when Atom: atom(), Encoding: :latin1 | :utf8"
+    expected_output = "(atom, encoding) :: binary() when atom: atom(), encoding: :latin1 | :utf8"
 
     assert pretty_printed == expected_output
   end

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -423,6 +423,28 @@ defmodule Erlex.Test.PretyPrintTest do
     assert pretty_printed == expected_output
   end
 
+  test "underscore in when type variable prints appropriately" do
+    input = ~S"""
+    (This_one, any()) -> 'ok' when This_one :: key()
+    """
+
+    pretty_printed = Erlex.pretty_print_contract(input)
+
+    expected_output = "(this_one, any()) :: :ok when this_one: key()"
+    assert pretty_printed == expected_output
+  end
+
+  test "mixed case in when type variable prints appropriately" do
+    input = ~S"""
+    (ThisOne, any()) -> 'ok' when ThisOne :: key()
+    """
+
+    pretty_printed = Erlex.pretty_print_contract(input)
+
+    expected_output = "(thisOne, any()) :: :ok when thisOne: key()"
+    assert pretty_printed == expected_output
+  end
+
   test "whens with single letter type variables prints appropriately" do
     input = ~S"""
     () -> a when a :: atom()


### PR DESCRIPTION
Follow-up to [this discussion](https://github.com/asummers/erlex/pull/39#discussion_r305156607). 

In Erlang and Elixir syntax, the names used in a spec `when` clause are variables - type variables. So in Erlang they must follow [Erlang's variable syntax](http://erlang.org/doc/reference_manual/expressions.html#variables):

> Variables start with an uppercase letter or underscore (_). Variables can contain alphanumeric characters, underscore and @.

In Elixir variables must begin with a lower case letter or underscore, and can contain upper/lower case letters, numbers and underscores.

So if we want Erlex pretty printed Erlang contracts to compile in Elixir, we need to transform legal Erlang type variable names to legal Elixir type variable names.

This PR helps us do that. It will lowercase the first character of an uppercase variable name used in when clauses. It also fixes a bug I introduced in the last PR that caused an exception on type variables including underscores, since those don't get lexed as a legal charlist and I was just calling `to_string()` on it.

But now the original example code:

```elixir
  def bad_func do
    Atom.to_string("not a string")
  end
```
Will give the error referencing the [Erlang spec](https://github.com/erlang/otp/blob/master/erts/preloaded/src/erlang.erl#L345):

```erlang
%% atom_to_binary/2
-spec atom_to_binary(Atom, Encoding) -> binary() when
      Atom :: atom(),
      Encoding :: latin1 | unicode | utf8.
```

as:

```
lib/example.ex:8:call
The function call will not succeed.

:erlang.atom_to_binary("not a string", :utf8)

breaks the contract
(atom, encoding) :: binary() when atom: atom(), encoding: :latin1 | :unicode | :utf8
```

We can copy paste that contract into our own Elixir module, and it compiles and works with dialyzer.

```elixir
defmodule Example do
  @spec to_string(atom, encoding) :: binary()  when atom: atom(), encoding: :latin1 | :utf8
  def to_string(atom, encoding) do
    :erlang.atom_to_binary(atom, encoding)
  end

  def bad_func do
    __MODULE__.to_string("not a string", :utf8)
  end
end
```
Gives:

```
lib/example.ex:8:call
The function call will not succeed.

Example.to_string("not a string", :utf8)

will never return since the success typing is:
(atom(), :latin1 | :unicode | :utf8) :: binary()

and the contract is
(atom, encoding) :: binary() when atom: atom(), encoding: :latin1 | :utf8
```

One possible issue still outstanding is that an Erlang variable could contain an ampersand. Currently that throws an error in the parser, I'm not sure why though.
