### PR TITLE
Fix lexer to tokenize triple '<' properly

### DIFF
--- a/src/lexer.xrl
+++ b/src/lexer.xrl
@@ -31,6 +31,7 @@ _ : {token, {'_',  TokenLine}}.
 \=\> : {token, {'=>',  TokenLine}}.
 \-\> : {token, {'->',  TokenLine}}.
 \| : {token, {'|',  TokenLine}}.
+\<\<\< : {token, {'<', TokenLine}, "<<"}.
 \<\< : {token, {'<<', TokenLine}}.
 \< : {token, {'<', TokenLine}}.
 \>\> : {token, {'>>', TokenLine}}.

--- a/test/pretty_print_test.exs
+++ b/test/pretty_print_test.exs
@@ -579,4 +579,12 @@ defmodule Erlex.Test.PretyPrintTest do
 
     assert pretty_printed == "(<<114, 111, 108, 101, 115, 95, 117, 115, 101, 114, 115>>)"
   end
+
+  test "binary as first value in pattern" do
+    input = "<<<_:8,_:_*1>>,'false'>"
+
+    pretty_printed = Erlex.pretty_print(input)
+
+    assert pretty_printed == "<<_ :: 8, _ :: size(1)>>, false"
+  end
 end


### PR DESCRIPTION
It was producing [<<, <] but it should [<, <<]. Added lexer rule with push back to fix it.

I was having troubles with dialyzer formatter to parse: `<<<_:8,_:_*1>>,'false'>`